### PR TITLE
fix check_version requiring minimum python version as 3.7 due to capture_output arg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.7'
         architecture: 'x64'
     - name: Install the library
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ jobs:
         architecture: 'x64'
     - name: Install the library
       run: |
-        pip install nbdev jupyter
+        pip install -U pip=21.2.4
+        pip install nbdev jupyter nbverbose
         pip install -e .
     - name: Read all notebooks
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
         architecture: 'x64'
     - name: Install the library
       run: |
-        pip install -U pip==21.2.4
         pip install nbdev jupyter nbverbose
         pip install -e .
     - name: Read all notebooks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         architecture: 'x64'
     - name: Install the library
       run: |
-        pip install -U pip=21.2.4
+        pip install -U pip==21.2.4
         pip install nbdev jupyter nbverbose
         pip install -e .
     - name: Read all notebooks

--- a/settings.ini
+++ b/settings.ini
@@ -22,7 +22,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = pipdeptree==2.1.0 pip==21.2.4
+requirements = pipdeptree==2.1.0
 # Optional. Same format as setuptools console_scripts
 # console_scripts = 
 # Optional. Same format as setuptools dependency-links

--- a/settings.ini
+++ b/settings.ini
@@ -11,7 +11,7 @@ author_email = muellerzr@gmail.com
 copyright = Zachary Mueller
 branch = master
 version = 0.0.1
-min_python = 3.6
+min_python = 3.7
 audience = Developers
 language = English
 # Set to True if you want to create a more fancy sidebar.json than the default
@@ -22,7 +22,7 @@ license = apache2
 status = 2
 
 # Optional. Same format as setuptools requirements
-requirements = pipdeptree==2.1.0
+requirements = pipdeptree==2.1.0 pip==21.2.4
 # Optional. Same format as setuptools console_scripts
 # console_scripts = 
 # Optional. Same format as setuptools dependency-links


### PR DESCRIPTION
Adds a fix for https://github.com/muellerzr/dependency_checker/issues/6. This also includes installing specific pip version since the test (assert) validates this. And should fix the CI build 